### PR TITLE
Modify how representative documents are extracted

### DIFF
--- a/dsp_interview_transcripts/notebooks/representative_docs.ipynb
+++ b/dsp_interview_transcripts/notebooks/representative_docs.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "from bertopic import BERTopic\n",
+    "from bertopic.dimensionality import BaseDimensionalityReduction\n",
+    "from bertopic.representation import (\n",
+    "    KeyBERTInspired,\n",
+    "    MaximalMarginalRelevance,\n",
+    "    # OpenAI,\n",
+    "    PartOfSpeech,\n",
+    ")\n",
+    "from hdbscan import HDBSCAN\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "import random\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.preprocessing import normalize\n",
+    "import torch\n",
+    "from typing import List, Optional, Union\n",
+    "from umap import UMAP\n",
+    "\n",
+    "from dsp_interview_transcripts import PROJECT_DIR, logger\n",
+    "from dsp_interview_transcripts.utils.viz import create_scatterplot\n",
+    "from dsp_interview_transcripts.utils.repr_docs import *\n",
+    "\n",
+    "# Set random seeds\n",
+    "RANDOM_SEED = 42\n",
+    "np.random.seed(RANDOM_SEED)\n",
+    "random.seed(RANDOM_SEED)\n",
+    "torch.manual_seed(RANDOM_SEED)\n",
+    "\n",
+    "SENTENCE_MODEL = SentenceTransformer(\"all-MiniLM-L6-v2\")\n",
+    "\n",
+    "alt.data_transformers.disable_max_rows()\n",
+    "\n",
+    "pd.set_option(\"max_colwidth\", 1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"s3://dsp-qualfml/interim/user_messages_min_len_9_w_sentiment.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_reduction_model = BaseDimensionalityReduction()\n",
+    "\n",
+    "hdbscan_model = HDBSCAN(\n",
+    "    min_cluster_size=15,\n",
+    "    metric=\"euclidean\",\n",
+    "    cluster_selection_method=\"eom\",\n",
+    "    prediction_data=True,\n",
+    ")\n",
+    "\n",
+    "vectorizer_model = TfidfVectorizer(\n",
+    "    stop_words=\"english\",\n",
+    "    min_df=1,\n",
+    "    max_df=0.85,\n",
+    "    ngram_range=(1, 3),\n",
+    ")\n",
+    "\n",
+    "# KeyBERT\n",
+    "keybert_model = KeyBERTInspired()\n",
+    "\n",
+    "# MMR\n",
+    "mmr_model = MaximalMarginalRelevance(diversity=0.3)\n",
+    "\n",
+    "# All representation models\n",
+    "representation_model = {\n",
+    "                \"KeyBERT\": keybert_model,\n",
+    "                # \"OpenAI\": openai_model,  # Uncomment if you will use OpenAI\n",
+    "                \"MMR\": mmr_model,\n",
+    "                # \"POS\": pos_model,\n",
+    "            }\n",
+    "\n",
+    "topic_model = BERTopic(\n",
+    "                # Pipeline models\n",
+    "                embedding_model=\"sentence-transformers/all-MiniLM-L6-v2\",\n",
+    "                umap_model=empty_reduction_model,\n",
+    "                hdbscan_model=hdbscan_model,\n",
+    "                vectorizer_model=vectorizer_model,\n",
+    "                representation_model=representation_model,\n",
+    "                # Hyperparameters\n",
+    "                top_n_words=10,\n",
+    "                verbose=True,\n",
+    "                calculate_probabilities=True,\n",
+    "            )\n",
+    "            \n",
+    "# Convert NaNs to empty strings\n",
+    "df['text_clean'] = df['text_clean'].astype(str)\n",
+    "docs = df['text_clean'].tolist()\n",
+    "embeddings = SENTENCE_MODEL.encode(docs, show_progress_bar=True)\n",
+    "normalized_embeddings = normalize(embeddings, norm='l2')\n",
+    "umap_2d = UMAP(random_state=RANDOM_SEED, n_components=2)\n",
+    "embeddings_2d = umap_2d.fit_transform(normalized_embeddings)\n",
+    "\n",
+    "topics, probs = topic_model.fit_transform(docs, embeddings_2d)\n",
+    "\n",
+    "rep_docs = topic_model.get_representative_docs()\n",
+    "\n",
+    "topic_lookup = topic_model.get_topic_info()[[\"Topic\", \"Name\"]]\n",
+    "\n",
+    "df_vis = pd.DataFrame(embeddings_2d, columns=[\"x\", \"y\"])\n",
+    "df_vis[\"topic\"] = topics\n",
+    "df_vis = df_vis.merge(topic_lookup, left_on=\"topic\", right_on=\"Topic\", how=\"left\")\n",
+    "df_vis[\"doc\"] = docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_vis = pd.merge(\n",
+    "                    df[[\"uuid\",\"conversation\",'text_clean', 'sentiment', 'question', 'context']],\n",
+    "                    df_vis,\n",
+    "                    left_on='text_clean',\n",
+    "                    right_on=\"doc\",\n",
+    "                    how=\"outer\",\n",
+    "                )\n",
+    "\n",
+    "df_vis['Name'].value_counts(normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualise clusters\n",
+    "fig = create_scatterplot(df_vis, color=\"Name:N\", tooltip=[\"Name:N\", \"text_clean:N\"])\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_vis['norm_embedding'] = list(embeddings_2d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topic_lookup = topic_model.get_topic_info()[[\"Topic\", \"Representation\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_vis = (df_vis\n",
+    "          .merge(topic_lookup, left_on=\"topic\", right_on=\"Topic\", how=\"left\")\n",
+    "          .drop(columns=['Topic_y'])\n",
+    "          .rename(columns={'Topic_x': 'Topic'}))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_vis_no_noise = df_vis[df_vis['topic'] != -1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radius_distributions, clustered_data = get_min_radius(df_vis_no_noise, k_neighbours=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clustered_data['quartile'] = clustered_data.groupby('topic')['radius_10'].transform(\n",
+    "    lambda x: pd.qcut(x, q=4, labels=['1st', '2nd', '3rd', 'greater than 3rd'])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot histogram for each cluster's radius distribution\n",
+    "for cluster_label, radii in radius_distributions.items():\n",
+    "    cluster_size = len(clustered_data[clustered_data['topic'] == cluster_label])\n",
+    "    fig = px.histogram(\n",
+    "        x=radii,\n",
+    "        nbins=20,\n",
+    "        title=f'Radius Distribution for Cluster {cluster_label} ({cluster_size} points in cluster)',\n",
+    "        labels={'x': f'Smallest Radius containing 10 Neighbors', 'y': 'Frequency'}\n",
+    "    )\n",
+    "    fig.update_layout(xaxis_title=f'Smallest Radius containing 10 Neighbors', yaxis_title='Frequency')\n",
+    "    fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repr_docs = extract_repr_docs(clustered_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This plot unfortunately just doesn't seem informative\n",
+    "fig2 = create_scatterplot(clustered_data, color=\"quartile:N\", tooltip=[\"Name:N\", \"text_clean:N\"])\n",
+    "fig2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize 'radius_10' within each cluster\n",
+    "clustered_data['radius_10_zscore'] = clustered_data.groupby('Name')['radius_10'].transform(lambda x: abs(x - x.mean()) / x.std())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clustered_data['radius_10_zscore'].hist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This too isn't very helpful, even once we have removed outliers\n",
+    "fig = (\n",
+    "    alt.Chart(clustered_data[clustered_data['radius_10_zscore'] <3])\n",
+    "    .mark_circle(size=50)\n",
+    "    .encode(\n",
+    "        x=alt.X(\n",
+    "            \"x:Q\",\n",
+    "            axis=alt.Axis(ticks=False, labels=False, title=None, grid=False),\n",
+    "        ),\n",
+    "        y=alt.Y(\n",
+    "            \"y:Q\",\n",
+    "            axis=alt.Axis(ticks=False, labels=False, title=None, grid=False),\n",
+    "        ),\n",
+    "        color=alt.Color(\n",
+    "            \"radius_10_zscore:Q\",\n",
+    "            scale=alt.Scale(scheme=\"viridis\"),\n",
+    "            legend=alt.Legend(title=\"Z-Score of Radius\")\n",
+    "        ),\n",
+    "        shape=alt.Shape(\n",
+    "            \"Name:N\",\n",
+    "            legend=alt.Legend(title=\"Name\")\n",
+    "        ),\n",
+    "        tooltip=[\"Name:N\", \"text_clean:N\", \"radius_10_zscore:Q\"],\n",
+    "    )\n",
+    "    .properties(width=900, height=600)\n",
+    "    .interactive()\n",
+    ")\n",
+    "\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dsp_interview_transcripts/pipeline/name_clusters.py
+++ b/dsp_interview_transcripts/pipeline/name_clusters.py
@@ -1,8 +1,5 @@
 """Use a llama model to give names and descriptions for the topics."""
-import json
-
 from typing import Dict
-from typing import List
 
 import pandas as pd
 
@@ -67,8 +64,8 @@ def name_topics(
     topic_info: pd.DataFrame,
     llm_chain,
     text_col: str = "text_clean",
-    top_words_col: str = "Top Words",
-    topic_label_col: str = "Cluster",
+    top_words_col: str = "Representation",
+    topic_label_col: str = "Topic",
 ) -> Dict[str, dict]:
     """
     Generate names and descriptions for each topic by invoking an LLM chain,
@@ -102,7 +99,7 @@ def name_topics(
             "Topic 2": {"name": "Product Quality", "description": "Documents focusing on product durability and performance."}
         }
     """
-    topics = topic_info["Cluster"].unique().tolist()
+    topics = topic_info[topic_label_col].unique().tolist()
 
     results = {}
 
@@ -130,20 +127,20 @@ if __name__ == "__main__":
 
     topic_info = pd.read_csv(INPUT_PATH)
 
-    topic_info = topic_info.groupby(["Cluster", "Top Words"])["text_clean"].apply(list).reset_index()
-    topic_info["Cluster"] = topic_info["Cluster"].astype(str)
+    topic_info = topic_info.groupby(["Topic", "Representation"])["text_clean"].apply(list).reset_index()
+    topic_info["Topic"] = topic_info["Topic"].astype(str)
 
     results = name_topics(
-        topic_info, llm_chain, text_col="text_clean", top_words_col="Top Words", topic_label_col="Cluster"
+        topic_info, llm_chain, text_col="text_clean", top_words_col="Representation", topic_label_col="Topic"
     )
 
     # Some complicated conditionals to check that what's in `results` can be parsed
-    topic_info[f"{model}_name"] = topic_info["Cluster"].map(
+    topic_info[f"{model}_name"] = topic_info["Topic"].map(
         lambda x: results[x]["name"]
         if x in results and isinstance(results[x], dict) and "name" in results[x]
         else None
     )
-    topic_info[f"{model}_description"] = topic_info["Cluster"].map(
+    topic_info[f"{model}_description"] = topic_info["Topic"].map(
         lambda x: results[x]["description"]
         if x in results and isinstance(results[x], dict) and "description" in results[x]
         else None

--- a/dsp_interview_transcripts/pipeline/name_clusters.py
+++ b/dsp_interview_transcripts/pipeline/name_clusters.py
@@ -136,7 +136,7 @@ def main(production: bool = False):
 
     topic_info = get_rep_docs(production=production)
 
-    topic_info = topic_info.groupby(["Topic", "Representation"])["text_clean"].apply(list).reset_index()
+    topic_info = topic_info.groupby(["Topic", "Name", "Representation"])["text_clean"].apply(list).reset_index()
     topic_info["Topic"] = topic_info["Topic"].astype(str)
 
     results = name_topics(

--- a/dsp_interview_transcripts/pipeline/prep_output_tables.py
+++ b/dsp_interview_transcripts/pipeline/prep_output_tables.py
@@ -96,22 +96,34 @@ def main(production: bool = False):
     data = get_data_w_topics(production=production)
     data_w_names = get_topic_names(production=production)
 
-    topic_counts = pd.DataFrame(data["Cluster"].value_counts()).reset_index()
+    topic_counts = pd.DataFrame(data["Topic"].value_counts()).reset_index()
     topic_counts = topic_counts.rename(columns={"count": "N responses in topic"})
 
-    data_w_names = data_w_names.rename(columns={"llama3.2_name": "Name", "llama3.2_description": "Description"})
-    data_w_names = pd.merge(data_w_names, topic_counts, left_on="Cluster", right_on="Cluster", how="left")
+    data_w_names = pd.merge(data_w_names, topic_counts, left_on="Topic", right_on="Topic", how="left")
 
     rep_docs = pd.merge(
-        rep_docs, data_w_names[["Cluster", "Name", "Description", "N responses in topic"]], on="Cluster", how="left"
+        rep_docs,
+        data_w_names[["Topic", "llama3.2_name", "llama3.2_description", "N responses in topic"]],
+        on="Topic",
+        how="left",
     )
+    rep_docs = rep_docs.rename(
+        columns={
+            "Name": "keyword_name",
+            "Representation": "Top words",
+            "llama3.2_name": "Name",
+            "llama3.2_description": "Description",
+        }
+    )
+
     save_to_s3(
         S3_BUCKET,
         rep_docs[
             [
                 "Name",
                 "Description",
-                "Top Words",
+                "keyword_name",
+                "Top words",
                 "N responses in topic",
                 "conversation",
                 "uuid",
@@ -123,8 +135,9 @@ def main(production: bool = False):
         OUTPUT_PATH_SUMMARY,
     )
 
+    data = data.rename(columns={"Name": "keyword_name", "Representation": "Top words"})
     data_viz = (
-        data.merge(data_w_names[["Cluster", "Name", "Description"]], on="Cluster", how="left")
+        data.merge(rep_docs[["Topic", "Name", "Description"]], on="Topic", how="left")
         .assign(Name=lambda df: df["Name"].fillna("None"))
         .assign(Description=lambda df: df["Description"].fillna("None"))
     )
@@ -142,7 +155,8 @@ def main(production: bool = False):
         [
             "Name",
             "Description",
-            "Top Words",
+            "keyword_name",
+            "Top words",
             "Representative_of_topic",
             "question",
             "context",
@@ -160,15 +174,13 @@ def main(production: bool = False):
             "sentiment": "predicted_sentiment",
             "Name": "Topic Name",
             "Description": "Topic Description",
-            "Top Words": "Topic Top Words",
+            "Top words": "Topic Top Words",
         }
     ).sort_values(["conversation", "timestamp"])
 
     logger.info("Saving output table...")
 
     save_to_s3(S3_BUCKET, final_df, OUTPUT_PATH_FULL_DATA)
-
-    # final_df.sort_values(["conversation", "timestamp"]).to_csv(OUTPUT_PATH_FULL_DATA, index=False)
 
     # Visualise clusters
     logger.info("Saving figures...")

--- a/dsp_interview_transcripts/pipeline/run_pipeline.py
+++ b/dsp_interview_transcripts/pipeline/run_pipeline.py
@@ -34,9 +34,9 @@ def main(production: bool = False):
     logger.info("Running prep_output_tables.py...")
     subprocess.run(f"python {script_parent / 'prep_output_tables.py'} {mode_arg}", shell=True)
 
-    # Top down approach
-    logger.info("Running top_down_analysis.py...")
-    subprocess.run(f"python {script_parent / 'top_down_analysis.py'}", shell=True)
+    # # Top down approach
+    # logger.info("Running top_down_analysis.py...")
+    # subprocess.run(f"python {script_parent / 'top_down_analysis.py'}", shell=True)
 
 
 if __name__ == "__main__":

--- a/dsp_interview_transcripts/pipeline/topic_modelling.py
+++ b/dsp_interview_transcripts/pipeline/topic_modelling.py
@@ -1,167 +1,147 @@
 import random
 
-from collections import defaultdict
-
 import numpy as np
 import pandas as pd
 import torch
 
+from bertopic import BERTopic
+from bertopic.dimensionality import BaseDimensionalityReduction
+from bertopic.representation import KeyBERTInspired
+from bertopic.representation import MaximalMarginalRelevance
 from hdbscan import HDBSCAN
 from sentence_transformers import SentenceTransformer
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import normalize
 from umap import UMAP
 
 from dsp_interview_transcripts import PROJECT_DIR
 from dsp_interview_transcripts import logger
+from dsp_interview_transcripts.utils.repr_docs import *
 
 
 # Set random seeds
 RANDOM_SEED = 42
 np.random.seed(RANDOM_SEED)
 random.seed(RANDOM_SEED)
-# PyTorch seed (used by SentenceTransformer)
 torch.manual_seed(RANDOM_SEED)
 
 SENTENCE_MODEL = SentenceTransformer("all-MiniLM-L6-v2")
+
 DATA_PATH = PROJECT_DIR / "data/user_messages_min_len_9_w_sentiment.csv"
-MIN_CLUSTER_SIZE = 20
-
-umap_model = UMAP(
-    n_neighbors=15,
-    n_components=50,
-    min_dist=0.1,
-    metric="cosine",
-    random_state=RANDOM_SEED,
-)
-
-hdbscan_model = HDBSCAN(
-    min_cluster_size=MIN_CLUSTER_SIZE,
-    metric="euclidean",
-    cluster_selection_method="eom",
-    prediction_data=True,
-)
-
-vectorizer_model = TfidfVectorizer(
-    stop_words="english",
-    min_df=1,
-    max_df=0.85,
-    ngram_range=(1, 3),
-)
-
-
-def stratified_sample(group: pd.DataFrame, n: int = 10) -> pd.DataFrame:
-    """
-    Generate a stratified sample: get N responses stratified by
-    'question' and 'sentiment' values. The dataframe should already contain
-    just one topic ie one group.
-
-    Args:
-        group (pd.DataFrame): The DataFrame containing data for 1 topic to sample from.
-            Must contain 'question' and 'sentiment' columns.
-        n (int, optional): The number of samples to draw per 'question' and
-            'sentiment' combination. If there are fewer than `n` records in a
-            group, all available records are returned. Defaults to 10.
-
-    Returns:
-        pd.DataFrame: A new DataFrame containing the stratified sample.
-    """
-    # TODO: filter based on hdbscan probability
-    # TODO: find docs from centre of the cluster
-
-    # Calculate the sample size for each combination of 'question'
-    # and 'sentiment'
-    stratified_sample = group.groupby(["question", "sentiment"]).apply(
-        lambda x: x.sample(frac=min(1, n / len(group)), random_state=42)
-    )
-
-    # Reset the index to tidy up the resulting DataFrame
-    return stratified_sample.reset_index(drop=True)
-
 
 if __name__ == "__main__":
-    user_messages = pd.read_csv(DATA_PATH)
 
-    docs = user_messages["text_clean"].tolist()
-    logger.info("Embedding user messages...")
+    empty_reduction_model = BaseDimensionalityReduction()
+
+    umap_model = UMAP(
+        n_neighbors=15,
+        n_components=50,
+        min_dist=0.1,
+        metric="cosine",
+        random_state=RANDOM_SEED,
+    )
+
+    hdbscan_model = HDBSCAN(
+        min_cluster_size=20,
+        metric="euclidean",
+        cluster_selection_method="eom",
+        prediction_data=True,
+    )
+
+    vectorizer_model = TfidfVectorizer(
+        stop_words="english",
+        min_df=1,
+        max_df=0.85,
+        ngram_range=(1, 3),
+    )
+
+    # KeyBERT
+    keybert_model = KeyBERTInspired()
+
+    # MMR
+    mmr_model = MaximalMarginalRelevance(diversity=0.3)
+
+    # All representation models
+    representation_model = {
+        "KeyBERT": keybert_model,
+        # "OpenAI": openai_model,  # Uncomment if you will use OpenAI
+        "MMR": mmr_model,
+        # "POS": pos_model,
+    }
+
+    topic_model = BERTopic(
+        # Pipeline models
+        embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+        umap_model=empty_reduction_model,
+        hdbscan_model=hdbscan_model,
+        vectorizer_model=vectorizer_model,
+        representation_model=representation_model,
+        # Hyperparameters
+        top_n_words=10,
+        verbose=True,
+        calculate_probabilities=True,
+    )
+
+    df = pd.read_csv(DATA_PATH)
+
+    df["text_clean"] = df["text_clean"].astype(str)
+    docs = df["text_clean"].tolist()
     embeddings = SENTENCE_MODEL.encode(docs, show_progress_bar=True)
 
-    logger.info("Reducing dimensionality...")
-    umap_vectors = umap_model.fit_transform(embeddings)
+    embeddings_50d = umap_model.fit_transform(embeddings)
 
-    umap_df = pd.DataFrame(umap_vectors)
-    umap_df.columns = umap_df.columns.map(str)
-    user_messages_w_umap = pd.concat([user_messages.reset_index(), umap_df], axis=1)
+    normalized_embeddings = normalize(embeddings_50d, norm="l2")
 
-    umap_vars = [f"{i}" for i in range(50)]
-    model_vars = umap_vars
+    topics, probs = topic_model.fit_transform(docs, normalized_embeddings)
 
-    # Normalise the umap vectors
-    logger.info("Normalising UMAP vectors...")
-    scaler = StandardScaler()
-    df_normalized = scaler.fit_transform(user_messages_w_umap[model_vars])
+    rep_docs = topic_model.get_representative_docs()
 
-    logger.info("Fitting HDBSCAN...")
-    clusters = hdbscan_model.fit_predict(df_normalized)
-    cluster_probabilities = hdbscan_model.probabilities_
-    user_messages_w_umap["label"] = clusters
-    user_messages_w_umap["probs"] = cluster_probabilities
-    logger.info(user_messages_w_umap["label"].value_counts())
-
-    # 2d embeddings for visualisation
-    logger.info("Creating 2D embeddings for visualisation...")
     umap_2d = UMAP(random_state=RANDOM_SEED, n_components=2)
     embeddings_2d = umap_2d.fit_transform(embeddings)
 
-    # topic representations
-    logger.info("Creating tfidf representation...")
-    cluster_groups = user_messages_w_umap.groupby("label").agg({"text_clean": " ".join}).reset_index()
+    topic_lookup = topic_model.get_topic_info()[["Topic", "Name"]]
 
-    tfidf_matrix = vectorizer_model.fit_transform(cluster_groups["text_clean"].to_list())
+    df_vis = pd.DataFrame(embeddings_2d, columns=["x", "y"])
+    df_vis["topic"] = topics
+    df_vis = df_vis.merge(topic_lookup, left_on="topic", right_on="Topic", how="left")
+    df_vis["doc"] = docs
 
-    feature_names = vectorizer_model.get_feature_names_out()
-
-    # Create a dictionary to hold top words for each cluster
-    top_words_per_cluster = defaultdict(list)
-
-    # Number of top words you want to display per cluster
-    n_top_words = 10
-
-    # Iterate over each cluster and get top words
-    for cluster_idx, tfidf_scores in enumerate(tfidf_matrix):
-        # Get indices of top n words within the cluster
-        top_word_indices = tfidf_scores.toarray()[0].argsort()[: -n_top_words - 1 : -1]
-
-        # Get the top words corresponding to the top indices
-        top_words = [feature_names[i] for i in top_word_indices]
-
-        # Append the words to the dictionary
-        top_words_per_cluster[cluster_groups.iloc[cluster_idx]["label"]] = ", ".join(top_words)
-
-    top_words_df = pd.DataFrame(list(top_words_per_cluster.items()), columns=["Cluster", "Top Words"])
-
-    user_messages_w_umap_topics = pd.merge(
-        user_messages_w_umap, top_words_df, left_on="label", right_on="Cluster", how="left"
+    df_vis = pd.merge(
+        df[["uuid", "conversation", "text_clean", "sentiment", "question", "context"]],
+        df_vis,
+        left_on="text_clean",
+        right_on="doc",
+        how="outer",
     )
-    user_messages_w_umap_topics["x"] = embeddings_2d[:, 0]
-    user_messages_w_umap_topics["y"] = embeddings_2d[:, 1]
 
-    user_messages_w_umap_topics.to_csv(
-        PROJECT_DIR / "outputs/user_messages_min_len_9_w_sentiment_topics.csv", index=False
+    logger.info(f'Topic distribution: {df_vis["Name"].value_counts(normalize=True)}')
+
+    unique_conversations_per_topic = df_vis.groupby("Topic")["conversation"].nunique().reset_index()
+    unique_conversations_per_topic.columns = ["Topic", "N_users"]
+    logger.info(f"N users in each topic: {unique_conversations_per_topic}")
+
+    df_vis["norm_embedding"] = list(normalized_embeddings)
+
+    topic_lookup = topic_model.get_topic_info()[["Topic", "Representation"]]
+
+    df_vis = (
+        df_vis.merge(topic_lookup, left_on="topic", right_on="Topic", how="left")
+        .drop(columns=["Topic_y"])
+        .rename(columns={"Topic_x": "Topic"})
     )
+
+    # save df_vis
+    df_vis.to_csv(PROJECT_DIR / "outputs/user_messages_min_len_9_w_sentiment_topics.csv", index=False)
 
     # save most representative documents
+    df_vis_no_noise = df_vis[df_vis["topic"] != -1]
+    radius_distributions, clustered_data = get_min_radius(df_vis_no_noise, k_neighbours=10)
 
-    filtered_df = user_messages_w_umap_topics[
-        (user_messages_w_umap_topics["probs"] >= 0.5) & (user_messages_w_umap_topics["Cluster"] != -1)
-    ]
+    clustered_data["quartile"] = clustered_data.groupby("topic")["radius_10"].transform(
+        lambda x: pd.qcut(x, q=4, labels=["1st", "2nd", "3rd", "greater than 3rd"])
+    )
+    repr_docs = extract_repr_docs(clustered_data)
 
-    # Group by 'Cluster' and apply the stratified sampling
-    sampled_texts = filtered_df.groupby("Cluster").apply(stratified_sample).reset_index(drop=True)
-
-    # Keep only the first 10 samples per cluster
-    sampled_texts = sampled_texts.groupby("Cluster").head(10)
-
-    sampled_texts[
-        ["Cluster", "Top Words", "text_clean", "sentiment", "question", "context", "conversation", "uuid", "probs"]
+    repr_docs[
+        ["Topic", "Representation", "text_clean", "sentiment", "question", "context", "conversation", "uuid"]
     ].to_csv(PROJECT_DIR / "outputs/user_messages_min_len_9_w_sentiment_topics_representative_docs.csv", index=False)

--- a/dsp_interview_transcripts/pipeline/topic_modelling.py
+++ b/dsp_interview_transcripts/pipeline/topic_modelling.py
@@ -81,9 +81,7 @@ def main(production: bool = False):
     # All representation models
     representation_model = {
         "KeyBERT": keybert_model,
-        # "OpenAI": openai_model,  # Uncomment if you will use OpenAI
         "MMR": mmr_model,
-        # "POS": pos_model,
     }
 
     topic_model = BERTopic(
@@ -131,7 +129,7 @@ def main(production: bool = False):
     df_vis["doc"] = docs
 
     df_vis = pd.merge(
-        user_messages[["uuid", "conversation", "text_clean", "sentiment", "question", "context"]],
+        user_messages[["uuid", "conversation", "timestamp", "text_clean", "sentiment", "question", "context"]],
         df_vis,
         left_on="text_clean",
         right_on="doc",

--- a/dsp_interview_transcripts/pipeline/topic_modelling.py
+++ b/dsp_interview_transcripts/pipeline/topic_modelling.py
@@ -123,7 +123,7 @@ def main(production: bool = False):
     umap_2d = UMAP(random_state=RANDOM_SEED, n_components=2)
     embeddings_2d = umap_2d.fit_transform(embeddings)
 
-    topic_lookup = summary_info[["Topic", "Name"]]
+    topic_lookup = summary_info[["Topic", "Name", "Representation"]]
 
     df_vis = pd.DataFrame(embeddings_2d, columns=["x", "y"])
     df_vis["topic"] = topics
@@ -146,14 +146,6 @@ def main(production: bool = False):
 
     df_vis["norm_embedding"] = list(normalized_embeddings)
 
-    topic_lookup = topic_model.get_topic_info()[["Topic", "Representation"]]
-
-    df_vis = (
-        df_vis.merge(topic_lookup, left_on="topic", right_on="Topic", how="left")
-        .drop(columns=["Topic_y"])
-        .rename(columns={"Topic_x": "Topic"})
-    )
-
     logger.info("Saving data...")
     save_to_s3(S3_BUCKET, df_vis, OUT_PATH_FULL_DATA)
 
@@ -170,7 +162,17 @@ def main(production: bool = False):
     save_to_s3(
         S3_BUCKET,
         repr_docs[
-            ["Topic", "Representation", "text_clean", "sentiment", "question", "context", "conversation", "uuid"]
+            [
+                "Topic",
+                "Name",
+                "Representation",
+                "text_clean",
+                "sentiment",
+                "question",
+                "context",
+                "conversation",
+                "uuid",
+            ]
         ],
         OUT_PATH_REP_DOCS,
     )

--- a/dsp_interview_transcripts/utils/repr_docs.py
+++ b/dsp_interview_transcripts/utils/repr_docs.py
@@ -1,0 +1,96 @@
+from typing import Dict
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+from sklearn.metrics import pairwise_distances
+
+from dsp_interview_transcripts import logger
+
+
+def get_min_radius(
+    clustered_data: pd.DataFrame,
+    k_neighbours: int = 10,
+    topic_col: str = "topic",
+    embedding_col: str = "norm_embedding",
+) -> Tuple[Dict[int, np.ndarray], pd.DataFrame]:
+    """
+    Calculate the minimum radius that contains `k_neighbours` neighbors for each point in each cluster.
+    This is the distance away of the Kth nearest neighbour.
+
+    Args:
+        clustered_data (pd.DataFrame): DataFrame containing cluster labels and embeddings. One row per document.
+        k_neighbours (int): Number of neighbors to include within the radius. Default is 10.
+        topic_col (str): Column name identifying cluster labels. Default is 'topic'.
+        embedding_col (str): Column name containing embedding vectors. Default is 'norm_embedding'.
+
+    Returns:
+        Tuple[Dict[int, np.ndarray], pd.DataFrame]:
+            - Dictionary with cluster labels as keys and arrays of minimum radii for the points in the cluster.
+            - Modified DataFrame with an added column indicating the minimum radius for each point to its `k_neighbours`th neighbor.
+    """
+
+    clustered_data_copy = clustered_data.copy()
+
+    # Dictionary to store radius distributions for each cluster
+    radius_distributions = {}
+
+    # For each cluster, calculate the smallest radius that contains `k_neighbors` neighbors for each point
+    for cluster_label in clustered_data_copy[topic_col].unique():
+        # Get embeddings for the current cluster
+        cluster_points = clustered_data_copy[clustered_data_copy[topic_col] == cluster_label]
+        embeddings = np.vstack(cluster_points[embedding_col].values)  # Stack embeddings as an array
+
+        # Calculate pairwise distances within the cluster
+        # Because the embeddings are normalized, it shouldn't matter if we use euclidean or cosine? But euclidean is a bit easier to think about/write tests for?
+        distances = pairwise_distances(embeddings, metric="euclidean")
+
+        # Order the matrix so that the 0th column is the distance to itself,
+        # 1 column is distance to closest neighbour, 2 column is the distance to the second closest neighbour, etc.
+        sorted_distances = np.sort(distances, axis=1)
+        radii = sorted_distances[:, k_neighbours]
+
+        # Store minimum radii for this cluster
+        radius_distributions[cluster_label] = radii
+
+        # Add back into the dataframe
+        clustered_data_copy.loc[cluster_points.index, f"radius_{k_neighbours}"] = radii
+
+    return radius_distributions, clustered_data_copy
+
+
+def extract_repr_docs(clustered_data: pd.DataFrame, n: int = 10, random_seed: int = 42) -> pd.DataFrame:
+    """
+    Extract a representative sample of N documents for each topic.
+
+    We do this by finding documents that are in the most dense part or parts of the cluster
+    (those docs whose minimum radius to the 10th nearest point is in the first quartile of the distribution
+    of such distances for the cluster). We make sure each user is only represented once in the sample,
+    then take a random sample of n documents.
+
+    Args:
+        clustered_data (pd.DataFrame): DataFrame with cluster data including 'topic', 'conversation', and 'quartile' columns.
+
+    Returns:
+        pd.DataFrame: A DataFrame with a sample of documents, one per conversation in each topic,
+                      containing up to 10 documents per topic.
+    """
+    first_quartile_data = clustered_data[clustered_data["quartile"] == "1st"]
+
+    # Get info on the number of conversations (number of users) per topic
+    # - so that we know one user isn't dominating
+    distinct_conversations = first_quartile_data.groupby("topic")["conversation"].nunique().reset_index()
+    distinct_conversations.columns = ["topic", "distinct_conversations_in_1st_quartile"]
+    logger.info(f"Number of distinct conversations per topic: {distinct_conversations}")
+
+    # Keep only one response per user (conversation) in each topic
+    unique_conversations = first_quartile_data.drop_duplicates(subset=["topic", "conversation"])
+    # Take a random sample of 10
+    sampled_data = (
+        unique_conversations.groupby("topic")
+        .apply(lambda x: x.sample(n=n, random_state=random_seed) if len(x) >= n else x)
+        .reset_index(drop=True)
+    )
+
+    return sampled_data

--- a/dsp_interview_transcripts/utils/viz.py
+++ b/dsp_interview_transcripts/utils/viz.py
@@ -1,0 +1,64 @@
+from typing import List
+from typing import Optional
+from typing import Union
+
+import altair as alt
+import pandas as pd
+
+
+opacity_condition = alt.condition(alt.datum.Topic == -1, alt.value(0.1), alt.value(0.6))
+
+
+def create_scatterplot(
+    data_viz: pd.DataFrame,
+    color: str = "Name:N",
+    tooltip: List[str] = ["Name:N", "Description:N", "question:N", "text_clean:N"],
+    domain: Optional[List[Union[str, int]]] = None,
+    range_: Optional[List[str]] = None,
+) -> alt.Chart:
+    """
+    Display texts as a scatterplot.
+
+    domain and range_ are used for specifying a 3-way colour scale when the
+    texts should be coloured by sentiment.
+
+    Args:
+        data_viz (pd.DataFrame): The DataFrame containing data to visualize. Must include columns for x and y coordinates,
+            along with fields specified in `color` and `tooltip`.
+        color (str, optional): Encoding specification for the color channel. Defaults to "Name:N".
+        tooltip (List[str], optional): List of fields to display as tooltips. Defaults to ["Name:N", "Description:N", "question:N", "text_clean:N"].
+        domain (Optional[List[Union[str, int]]], optional): Custom domain values for the color scale, defining specific categories.
+            Defaults to None.
+        range_ (Optional[List[str]], optional): Custom color range for the color scale, corresponding to the domain values.
+            Defaults to None.
+
+    Returns:
+        alt.Chart: An Altair chart object representing the scatterplot, with specified color, tooltips, and interactivity.
+    """
+
+    if domain is not None and range_ is not None:
+        color = alt.Color(color, scale=alt.Scale(domain=domain, range=range_))
+    else:
+        color = alt.Color(color)
+
+    fig = (
+        alt.Chart(data_viz)
+        .mark_circle(size=50)
+        .encode(
+            x=alt.X(
+                "x:Q",
+                axis=alt.Axis(ticks=False, labels=False, title=None, grid=False),
+            ),
+            y=alt.Y(
+                "y:Q",
+                axis=alt.Axis(ticks=False, labels=False, title=None, grid=False),
+            ),
+            color=color,
+            opacity=opacity_condition,  # Ensure opacity_condition is defined elsewhere
+            tooltip=tooltip,
+        )
+        .properties(width=900, height=600)
+        .interactive()
+    )
+
+    return fig

--- a/tests/test_get_min_radius.py
+++ b/tests/test_get_min_radius.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from dsp_interview_transcripts.utils.repr_docs import get_min_radius
+
+
+@pytest.fixture
+def dummy_data():
+    """Dummy dataset with 2 clusters and 2D embeddings."""
+    return pd.DataFrame(
+        {
+            "topic": [0, 0, 0, 0, 1, 1, 1, 1],
+            "norm_embedding": [
+                np.array([0, 0]),  # Points in cluster 0
+                np.array([1, 0]),
+                np.array([0, 1]),
+                np.array([1, 1]),
+                np.array([4, 4]),  # Points in cluster 1
+                np.array([4, 9]),
+                np.array([9, 9]),
+                np.array([16, 16]),
+            ],
+        }
+    )
+
+
+def test_get_min_radius(dummy_data):
+
+    k_neighbours = 2
+
+    # Run the function
+    radius_distributions, result_df = get_min_radius(
+        dummy_data, k_neighbours=k_neighbours, topic_col="topic", embedding_col="norm_embedding"
+    )
+
+    # Test radius_distributions dictionary structure and values
+    for cluster_label, radii in radius_distributions.items():
+        assert len(radii) == 4
+        if cluster_label == 0:
+            # Cluster 0 points are close to each other; expect radius to be around 1
+            expected_radii = np.array([1, 1, 1, 1])
+        else:
+            # Cluster 1 points are further away from each other
+            expected_radii = np.array([7.07106781, 5, 7.07106781, 13.89244399])
+        np.testing.assert_almost_equal(radii, expected_radii, decimal=1)
+
+    # Test the result DataFrame has the expected radius column
+    assert f"radius_{k_neighbours}" in result_df.columns
+    assert len(result_df) == len(dummy_data)  # Should have the same length as input data
+
+    # Check values in the radius column match the expected radii
+    for cluster_label, group in result_df.groupby("topic"):
+        radii = group[f"radius_{k_neighbours}"].values
+        if cluster_label == 0:
+            expected_radii = np.array([1, 1, 1, 1])
+        else:
+            expected_radii = np.array([7.07106781, 5, 7.07106781, 13.89244399])
+        np.testing.assert_almost_equal(radii, expected_radii, decimal=1)


### PR DESCRIPTION
This PR:

- uses BERTopic for topic modelling, rather than implementing each component (UMAP, HDBSCAN, TFIDF) separately
- adds utils for extracting representative documents

There are also tests for some of the utils.

Please see if the methodology makes sense... I based it on the calculation of "core distances" as described in [this blog](https://pberba.github.io/stats/2020/01/17/hdbscan/). But now that I'm looking at it again, I don't know if it's enough just to look at how many neighbours a point has in Euclidean space. One way to check this would be to run the pipeline end to end (or at least up to the end of `topic_modelling.py`) and see if the documents selected as representative actually seem sensible.